### PR TITLE
Alterando altura do elemento para 100%

### DIFF
--- a/angular-amchart/amchart.js
+++ b/angular-amchart/amchart.js
@@ -6,7 +6,7 @@ angular.module('AngularAmChart', [])
                 scope: {
                     options: '=ngModel'
                 },
-                template: "<div class='amchart' style='width: 100%; height: 400px;'></div>",
+                template: "<div class='amchart' style='width: 100%; height: 100%;'></div>",
                 link: function (scope, $el) {
                     //Gerando um uid para colocar no elemento
                     var guid = function guid() {


### PR DESCRIPTION
Alterando a altura do elemento para 100% deixa o controle da altura para o elemento pai, sendo flexível para criar charts de linha bem pequenos.